### PR TITLE
 Deal with string for the `install_requires` line in setup.py

### DIFF
--- a/pydep/req.py
+++ b/pydep/req.py
@@ -48,6 +48,12 @@ def requirements_from_setup_py(rootdir):
     reqs = []
     if 'install_requires' in setup_dict:
         req_strs = setup_dict['install_requires']
+        # Deal with case like:
+        # install_requires = 'setuptools'
+        # where it should be
+        # install_requires = ['setuptools']
+        if isinstance(req_strs, str):
+            req_strs = [req_strs]
         for req_str in req_strs:
             reqs.append(SetupToolsRequirement(pr.Requirement.parse(req_str), path.join(rootdir, 'setup.py')))
     return reqs, None


### PR DESCRIPTION
    They should be arrays, but if you get a line like

    install_requires = 'setuptools'

    We want to deal with it properly